### PR TITLE
Added call to calc to fix deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.2
+
+- Changes to remove deprecation warnings related to Dart Saas divisions.
+
 # 2.0.1
 
 - I forgot to put a comma which messed up a selector for `li` elements with no siblings causing unexpected behavior with vertical connectors. That comma is back in its place.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeflex",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Treeflex is a flexbox based CSS library for drawing hierarchy trees with HTML lists.",
   "keywords": ["css", "flexbox", "scss", "hierarchy tree", "tree", "css tree"],
   "main": "/docs/index.html",

--- a/src/core/scss/treeflex.scss
+++ b/src/core/scss/treeflex.scss
@@ -62,7 +62,7 @@ $connector_style: solid;
     position: relative;
     display: inline-block;
     border: $connector_width solid $primary_color;
-    padding: ($node_gap / 2) $node_gap;
+    padding: calc($node_gap / 2) $node_gap;
 
     &:before {
       position: absolute;


### PR DESCRIPTION
Added an additional calc() to prevent these errors:

```
023-09-17 19:38:28 <w> Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Recommendation: math.div($connector-width, 2) or calc($connector-width / 2)
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> More info and automated migrator: https://sass-lang.com/d/slash-div
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> node_modules/treeflex/src/core/scss/treeflex.scss 36:25  @import
2023-09-17 19:38:28 <w> assets/css/tree.scss 1:9                                 root stylesheet
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Recommendation: math.div($connector-width, 2) or calc($connector-width / 2)
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> More info and automated migrator: https://sass-lang.com/d/slash-div
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> node_modules/treeflex/src/core/scss/treeflex.scss 37:35  @import
2023-09-17 19:38:28 <w> assets/css/tree.scss 1:9                                 root stylesheet
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Recommendation: math.div($connector-width, 2) or calc($connector-width / 2)
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> More info and automated migrator: https://sass-lang.com/d/slash-div
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> node_modules/treeflex/src/core/scss/treeflex.scss 44:26  @import
2023-09-17 19:38:28 <w> assets/css/tree.scss 1:9                                 root stylesheet
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Recommendation: math.div($connector-width, 2) or calc($connector-width / 2)
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> More info and automated migrator: https://sass-lang.com/d/slash-div
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> node_modules/treeflex/src/core/scss/treeflex.scss 49:27  @import
2023-09-17 19:38:28 <w> assets/css/tree.scss 1:9                                 root stylesheet
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Deprecation Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> Recommendation: math.div($node-gap, 2) or calc($node-gap / 2)
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> More info and automated migrator: https://sass-lang.com/d/slash-div
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> node_modules/treeflex/src/core/scss/treeflex.scss 65:15  @import
2023-09-17 19:38:28 <w> assets/css/tree.scss 1:9                                 root stylesheet
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> 8 repetitive deprecation warnings omitted.
2023-09-17 19:38:28 <w> 
2023-09-17 19:38:28 <w> null
2023-09-17 19:38:28
```